### PR TITLE
Add timezone abbrev to farm start copy

### DIFF
--- a/src/components/FarmListing.vue
+++ b/src/components/FarmListing.vue
@@ -245,7 +245,7 @@
                           <el-col :span="8" style="padding: 10px 20px;">
                             <div style="margin-bottom: 8px;">
                               <strong style="color: #1EC37F; font-size: 14px; text-transform: uppercase;" v-if="!farm.started">
-                                  Farming starts {{ farm.startTime | moment("calendar") }} and lasts {{ farm.duration | humanizeDuration }}
+                                  Farming starts {{ farm.startTime | moment("calendar") }} {{ localAbbrevTimeZone }} and lasts {{ farm.duration | humanizeDuration }}
                               </strong>
                               <strong style="color: #757679; font-size: 14px; text-transform: uppercase;" v-if="farm.started && !farm.ended">Farming ends {{ farm.endTime | moment("dddd, MMMM Do YYYY, h:mm a") }}</strong>
                               <strong style="color: #555CFF; font-size: 14px; text-transform: uppercase;" v-if="farm.ended">Farming complete</strong>
@@ -527,6 +527,7 @@ export default {
   },
   data() {
     return {
+      localAbbrevTimeZone: new Date().toLocaleTimeString('en-us',{ timeZoneName:'short' }).split(' ')[2],
       showUsd: false,
       stakeForm: {
         input: "",


### PR DESCRIPTION
Small/simple introductory pull request. This just adds the abbreviated time zone to the farm start date/time output when a farm hasn't started yet.

<img width="947" alt="Screen Shot 2021-07-01 at 4 53 58 PM" src="https://user-images.githubusercontent.com/123112/124201671-78641180-da8d-11eb-88e4-f7cbce1d46e2.png">
