### PR TITLE
fix: display up to 4 decimal places for tooltip chart

### DIFF
--- a/src/components/TrackerOverviewChart.vue
+++ b/src/components/TrackerOverviewChart.vue
@@ -159,7 +159,7 @@ export default {
           toolTip.style.display = "block";
           const price = param.seriesPrices.get(areaSeries);
           toolTip.innerHTML = `<div style="color: ${"rgba( 38, 166, 154, 1)"}">Crunchy.</div><div style="font-size: 24px; margin: 4px 0px; color: ${"black"}">
-            $${Math.round(100 * price) / 100}
+            $${Math.round(10000 * price) / 10000}
             </div><div style="color: ${"black"}">
             ${dateStr}
             </div>`;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/62065172/204818026-2aa3e401-1522-4b30-be88-1921ecd9efaa.png)
